### PR TITLE
Add a flag to use metadata describe for field permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /lib
 /node_modules
 /tmp
-/testProject
+/testProject*
 dump.rdb
 
 mshanemc-*

--- a/package-lock.json
+++ b/package-lock.json
@@ -4900,9 +4900,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5197,6 +5197,30 @@
         "mkdirp": "~0.5.1",
         "ncp": "~2.0.0",
         "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
       }
     },
     "nan": {
@@ -9481,25 +9505,11 @@
       }
     },
     "rimraf": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^6.0.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
+        "glob": "^7.1.3"
       }
     },
     "rsvp": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "fs-extra": "^7.0.1",
     "js2xmlparser": "^3.0.0",
     "json2csv": "^4.3.5",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "npm": "^6.8.0",
     "puppeteer": "^1.12.2",
     "puppeteer-core": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/request-promise-native": "^1.0.15",
     "@types/unzipper": "^0.9.1",
     "jest": "^24.3.1",
+    "rimraf": "^2.6.3",
     "ts-jest": "^24.0.0",
     "ts-node": "^7.0.1",
     "tslint": "^5.13.0",
@@ -114,8 +115,8 @@
   },
   "repository": "mshanemc/shane-sfdx-plugins",
   "scripts": {
-    "build": "rm -rf lib && tsc",
-    "clean": "rm -f .oclif.manifest.json",
+    "build": "rimraf -rf lib && tsc",
+    "clean": "rimraf -f .oclif.manifest.json",
     "lint": "tsc -p test --noEmit && tslint -p test -t stylish",
     "postpublish": "yarn run clean; git push; git push --tags",
     "posttest": "",

--- a/src/commands/shane/object/tab.ts
+++ b/src/commands/shane/object/tab.ts
@@ -7,25 +7,35 @@ import * as options from '../../../shared/js2xmlStandardOptions';
 import chalk from 'chalk';
 
 export default class ObjectTab extends SfdxCommand {
-
-  public static description = 'create a tab from a custom object, and you have to pick an';
+  public static description = 'create a tab from a custom object, and you have to pick an icon';
 
   public static examples = [
-`sfdx shane:object:tab -o SomeObject__c -i 86
+    `sfdx shane:object:tab -o SomeObject__c -i 86
 // create a tab for the object using icon #86 from https://lightningdesignsystem.com/icons/#custom
 `
   ];
 
   protected static flagsConfig = {
-    object: flags.string({char: 'o', required: true, description: 'object api name'}),
-    icon: flags.integer({char: 'i', required: true, min: 1, max: 100, description: 'icon number from https://lightningdesignsystem.com/icons/#custom but only up to 100'}),
-    target: flags.directory({char: 't', default: 'force-app/main/default', description: 'where to create the folder (if it doesn\'t exist already) and file...defaults to force-app/main/default' })
+    object: flags.string({ char: 'o', required: true, description: 'object api name' }),
+    icon: flags.integer({
+      char: 'i',
+      required: true,
+      min: 1,
+      max: 100,
+      description: 'icon number from https://lightningdesignsystem.com/icons/#custom but only up to 100'
+    }),
+    target: flags.directory({
+      char: 't',
+      default: 'force-app/main/default',
+      description: "where to create the folder (if it doesn't exist already) and file...defaults to force-app/main/default"
+    })
   };
 
   // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
   protected static requiresProject = true;
 
-  public async run(): Promise<any> { // tslint:disable-line:no-any
+  public async run(): Promise<any> {
+    // tslint:disable-line:no-any
 
     // remove trailing slash if someone entered it
     if (this.flags.target.endsWith('/')) {
@@ -36,11 +46,10 @@ export default class ObjectTab extends SfdxCommand {
     await fs.ensureDir(`${this.flags.target}/tabs`);
 
     const settingJSON = {
-      '@' : {
+      '@': {
         xmlns: 'http://soap.sforce.com/2006/04/metadata'
       },
-      customObject : true,
-      mobileReady : false,
+      customObject: true,
       motif: tabDefs.find(tab => tab.includes(`Custom${this.flags.icon}:`))
     };
 
@@ -52,4 +61,105 @@ export default class ObjectTab extends SfdxCommand {
   }
 }
 
-const tabDefs = ['Custom20: Airplane', 'Custom25: Alarm clock', 'Custom51: Apple', 'Custom52: Balls', 'Custom16: Bank', 'Custom53: Bell', 'Custom50: Big top', 'Custom54: Boat', 'Custom55: Books', 'Custom56: Bottle', 'Custom13: Box', 'Custom37: Bridge', 'Custom24: Building', 'Custom57: Building Block', 'Custom58: Caduceus', 'Custom38: Camera', 'Custom59: Can', 'Custom31: Car', 'Custom61: Castle', 'Custom49: CD/DVD', 'Custom28: Cell phone', 'Custom62: Chalkboard', 'Custom47: Knight', 'Custom63: Chip', 'Custom12: Circle', 'Custom64: Compass', 'Custom21: Computer', 'Custom40: Credit card', 'Custom99: TV CRT', 'Custom65: Cup', 'Custom33: Desk', 'Custom8: Diamond', 'Custom66: Dice', 'Custom32: Factory', 'Custom2: Fan', 'Custom26: Flag', 'Custom18: Form', 'Custom67: Gears', 'Custom68: Globe', 'Custom69: Guitar', 'Custom44: Hammer', 'Custom14: Hands', 'Custom70: Handsaw', 'Custom71: Headset', 'Custom1: Heart', 'Custom72: Helicopter', 'Custom4: Hexagon ', 'Custom73: Highway Sign', 'Custom74: Hot Air Balloon', 'Custom34: Insect', 'Custom75: IP Phone', 'Custom43: Jewel', 'Custom76: Keys', 'Custom27: Laptop', 'Custom5: Leaf', 'Custom9: Lightning', 'Custom77: Locked', 'Custom23: Envelope', 'Custom78: Map', 'Custom79: Measuring Tape', 'Custom35: Microphone', 'Custom10: Moon', 'Custom80: Motorcycle', 'Custom81: Musical Note', 'Custom29: PDA', 'Custom83: Pencil', 'Custom15: People', 'Custom22: Telephone', 'Custom46: Stamp', 'Custom84: Presenter', 'Custom30: Radar dish', 'Custom85: Real Estate Sign', 'Custom86: Red Cross', 'Custom17: Sack', 'Custom87: Safe', 'Custom88: Sailboat', 'Custom89: Saxophone', 'Custom90: Scales', 'Custom91: Shield', 'Custom92: Ship', 'Custom93: Shopping Cart', 'Custom7: Square', 'Custom41: Cash', 'Custom11: Star', 'Custom94: Stethoscope', 'Custom95: Stopwatch', 'Custom96: Street Sign', 'Custom3: Sun', 'Custom39: Telescope', 'Custom97: Thermometer', 'Custom45: Ticket', 'Custom36: Train', 'Custom42: Treasure chest', 'Custom6: Triangle', 'Custom48: Trophy', 'Custom98: Truck', 'Custom100: TV Widescreen', 'Custom60: Umbrella', 'Custom82: Whistle', 'Custom19: Wrench'];
+const tabDefs = [
+  'Custom20: Airplane',
+  'Custom25: Alarm clock',
+  'Custom51: Apple',
+  'Custom52: Balls',
+  'Custom16: Bank',
+  'Custom53: Bell',
+  'Custom50: Big top',
+  'Custom54: Boat',
+  'Custom55: Books',
+  'Custom56: Bottle',
+  'Custom13: Box',
+  'Custom37: Bridge',
+  'Custom24: Building',
+  'Custom57: Building Block',
+  'Custom58: Caduceus',
+  'Custom38: Camera',
+  'Custom59: Can',
+  'Custom31: Car',
+  'Custom61: Castle',
+  'Custom49: CD/DVD',
+  'Custom28: Cell phone',
+  'Custom62: Chalkboard',
+  'Custom47: Knight',
+  'Custom63: Chip',
+  'Custom12: Circle',
+  'Custom64: Compass',
+  'Custom21: Computer',
+  'Custom40: Credit card',
+  'Custom99: TV CRT',
+  'Custom65: Cup',
+  'Custom33: Desk',
+  'Custom8: Diamond',
+  'Custom66: Dice',
+  'Custom32: Factory',
+  'Custom2: Fan',
+  'Custom26: Flag',
+  'Custom18: Form',
+  'Custom67: Gears',
+  'Custom68: Globe',
+  'Custom69: Guitar',
+  'Custom44: Hammer',
+  'Custom14: Hands',
+  'Custom70: Handsaw',
+  'Custom71: Headset',
+  'Custom1: Heart',
+  'Custom72: Helicopter',
+  'Custom4: Hexagon ',
+  'Custom73: Highway Sign',
+  'Custom74: Hot Air Balloon',
+  'Custom34: Insect',
+  'Custom75: IP Phone',
+  'Custom43: Jewel',
+  'Custom76: Keys',
+  'Custom27: Laptop',
+  'Custom5: Leaf',
+  'Custom9: Lightning',
+  'Custom77: Locked',
+  'Custom23: Envelope',
+  'Custom78: Map',
+  'Custom79: Measuring Tape',
+  'Custom35: Microphone',
+  'Custom10: Moon',
+  'Custom80: Motorcycle',
+  'Custom81: Musical Note',
+  'Custom29: PDA',
+  'Custom83: Pencil',
+  'Custom15: People',
+  'Custom22: Telephone',
+  'Custom46: Stamp',
+  'Custom84: Presenter',
+  'Custom30: Radar dish',
+  'Custom85: Real Estate Sign',
+  'Custom86: Red Cross',
+  'Custom17: Sack',
+  'Custom87: Safe',
+  'Custom88: Sailboat',
+  'Custom89: Saxophone',
+  'Custom90: Scales',
+  'Custom91: Shield',
+  'Custom92: Ship',
+  'Custom93: Shopping Cart',
+  'Custom7: Square',
+  'Custom41: Cash',
+  'Custom11: Star',
+  'Custom94: Stethoscope',
+  'Custom95: Stopwatch',
+  'Custom96: Street Sign',
+  'Custom3: Sun',
+  'Custom39: Telescope',
+  'Custom97: Thermometer',
+  'Custom45: Ticket',
+  'Custom36: Train',
+  'Custom42: Treasure chest',
+  'Custom6: Triangle',
+  'Custom48: Trophy',
+  'Custom98: Truck',
+  'Custom100: TV Widescreen',
+  'Custom60: Umbrella',
+  'Custom82: Whistle',
+  'Custom19: Wrench'
+];

--- a/src/commands/shane/permset/create.ts
+++ b/src/commands/shane/permset/create.ts
@@ -66,12 +66,16 @@ export default class PermSetCreate extends SfdxCommand {
 
   // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
   protected static requiresProject = true;
-  protected static requiresUsername = true;
+  protected static supportsUsername = true;
 
   public async run(): Promise<any> {
     // tslint:disable-line:no-any
 
-    conn = this.org.getConnection();
+    // fail early on lack of username
+    if (this.flags.checkpermissionable && !this.org) {
+      throw new SfdxError(`username is required when using --checkpermissionable`);
+    }
+
     objectDescribe = new Map<string, Map<String, any>>();
 
     // validations
@@ -107,6 +111,8 @@ export default class PermSetCreate extends SfdxCommand {
     this.ux.log(`Object list is ${objectList}`);
 
     if (this.flags.checkpermissionable) {
+      conn = this.org.getConnection();
+
       this.ux.startSpinner('Getting objects describe from org');
 
       if (objectList.has('Activity')) {

--- a/src/commands/shane/permset/create.ts
+++ b/src/commands/shane/permset/create.ts
@@ -43,7 +43,8 @@ export default class PermSetCreate extends SfdxCommand {
     field: flags.string({  char: 'f', description: 'API name of an field to add perms for.  Required --object If blank, then you mean all the fields', dependsOn: ['object']}),
     directory: flags.directory({  char: 'd', default: 'force-app/main/default', description: 'Where is all this metadata? defaults to force-app/main/default' }),
     tab: flags.boolean({ char: 't', description: 'also add the tab for the specified object (or all objects if there is no specified objects)' }),
-    checkpermissionable: flags.boolean({ char: 'c', description: 'some fields\'permissions can\'t be deducted from metadata, use describe on org to check if field is permissionable' })
+    checkpermissionable: flags.boolean({ char: 'c', description: 'some fields\'permissions can\'t be deducted from metadata, use describe on org to check if field is permissionable' }),
+    verbose: flags.builtin()
   };
 
   // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
@@ -260,7 +261,9 @@ export default class PermSetCreate extends SfdxCommand {
         const parseString = util.promisify(parser.parseString);
         const fieldJSON = await parseString(fs.readFileSync(`${targetLocationObjects}/${objectName}/fields/${fieldName}.field-meta.xml`));
 
-        this.ux.logJson(fieldJSON);
+        if (this.flags.verbose) {
+          this.ux.logJson(fieldJSON);
+        }
 
         // Is it required at the DB level?
         if (fieldJSON.CustomField.required === 'true' || fieldJSON.CustomField.type === 'MasterDetail' || !fieldJSON.CustomField.type || fieldJSON.CustomField.fullName === 'OwnerId') {

--- a/src/commands/shane/permset/create.ts
+++ b/src/commands/shane/permset/create.ts
@@ -86,7 +86,7 @@ export default class PermSetCreate extends SfdxCommand {
 
     this.ux.log(`Object list is ${objectList}`);
 
-    if (this.flags.check) {
+    if (this.flags.checkpermissionable) {
       this.ux.startSpinner('Getting objects describe from org');
 
       if (objectList.includes('Activity')) {
@@ -215,7 +215,7 @@ export default class PermSetCreate extends SfdxCommand {
     } else {
 
       // get the field
-      if (this.flags.check) {
+      if (this.flags.checkpermissionable) {
 
         // Use org instead to know if field is creatable/updatable/permissionable
         if (objectDescribe.has(objectName) && objectDescribe.get(objectName).has(fieldName)) {

--- a/test/commands/shane/heroku/heroku.test.ts
+++ b/test/commands/shane/heroku/heroku.test.ts
@@ -31,8 +31,11 @@ describe('shane:heroku:connect', () => {
     });
 
     it('sets up a heroku app with deploy', async () => {
-      // sfdx shane:heroku:repo:deploy -g mshanemc -r electron-web-app -n `basename "${PWD/mshanemc-/}"` -t autodeployed-demos
-      const results = await exec('sfdx shane:heroku:repo:deploy -g mshanemc -r electron-web-app -n `basename "${PWD/mshanemc-/}"` -t autodeployed-demos --json', { cwd: testProjectName });
+      // sfdx shane:heroku:repo:deploy -g mshanemc -r electron-web-app -n `basename "${PWD/mshanemc-/}"` -t ci-tests
+      const results = await exec(
+        'sfdx shane:heroku:repo:deploy -g mshanemc -r electron-web-app -n `basename "${PWD/mshanemc-/}"` -t ci-tests --json',
+        { cwd: testProjectName }
+      );
 
       expect(results).toBeTruthy();
       expect(results.stdout).toBeTruthy();
@@ -42,12 +45,14 @@ describe('shane:heroku:connect', () => {
 
     it('configures connect with json response', async () => {
       // sfdx shane:heroku:connect -a `basename "${PWD/mshanemc-/}"` -f assets/herokuConnect/electron-web.json
-      const results = await exec('sfdx shane:heroku:connect -a `basename "${PWD/mshanemc-/}"` -f mapping.json -e custom --json', { cwd: testProjectName });
+      const results = await exec('sfdx shane:heroku:connect -a `basename "${PWD/mshanemc-/}"` -f mapping.json -e custom --json', {
+        cwd: testProjectName
+      });
 
-      console.log(results);
+      // console.log(results);
       expect(results).toBeTruthy();
       expect(results.stdout).toBeTruthy();
-      console.log(results.stdout);
+      // console.log(results.stdout);
       const stdout = JSON.parse(stripcolor(results.stdout));
       expect(stdout.status).toBe(0);
     });
@@ -106,5 +111,4 @@ describe('shane:heroku:connect', () => {
       version: 1
     };
   }
-
 });

--- a/test/commands/shane/object/tab.test.ts
+++ b/test/commands/shane/object/tab.test.ts
@@ -15,7 +15,6 @@ const label = 'Corgi';
 const plural = 'Corgi';
 
 describe('shane:object:create (regular object flavor)', () => {
-
   jest.setTimeout(testutils.localTimeout);
 
   beforeAll(async () => {
@@ -24,10 +23,12 @@ describe('shane:object:create (regular object flavor)', () => {
   });
 
   it('creates an object with all params supplied for a Text Name', async () => {
-
     // `sfdx shane:object:create --label "Platypus" --plural "${plural}" --api Platypus__b --directory /my / project / path
 
-    await exec(`sfdx shane:object:create --type custom --label "${label}" --plural "${plural}" --api ${api} --nametype Text --sharingmodel ReadWrite`, { cwd: testProjectName });
+    await exec(
+      `sfdx shane:object:create --type custom --label "${label}" --plural "${plural}" --api ${api} --nametype Text --sharingmodel ReadWrite`,
+      { cwd: testProjectName }
+    );
     expect(fs.existsSync(`${testProjectName}/force-app/main/default/objects/${api}`)).toBe(true);
     expect(fs.existsSync(`${testProjectName}/force-app/main/default/objects/${api}/fields`)).toBe(true);
     expect(fs.existsSync(`${testProjectName}/force-app/main/default/objects/${api}/${api}.object-meta.xml`)).toBe(true);
@@ -43,7 +44,6 @@ describe('shane:object:create (regular object flavor)', () => {
     await exec(`sfdx shane:object:tab --object ${api} --icon 1`, { cwd: testProjectName });
     const parsedTab = await testutils.getParsedXML(`${testProjectName}/force-app/main/default/tabs//${api}.tab-meta.xml`);
     expect(parsedTab.CustomTab.customObject).toBe('true');
-    expect(parsedTab.CustomTab.mobileReady).toBe('false');
     expect(parsedTab.CustomTab.motif).toBe('Custom1: Heart');
   });
 


### PR DESCRIPTION
I was getting some errors while deploying a Permission Set created with `shane:permset:create`: **You cannot deploy to a required field**.

This is because the metadata of some standard fields isn't enough to know if the field is permissionable or not.

For instance `Territory2.ForecastUserId` and 
`Territory2.Territory2TypeId` looks exactly the same when you look at the metadata, but one is permissionable whereas the other is not.

I've added a `--checkpermissionable` flag that will call the tooling api to describe the fields and check if it's permissionable or not. Obviously not as performant as before, but is working for 100% of the fields. Without the flag, the default behavior is unchanged.

One drawback, I've added `requiresUsername = true`. This is because it was harder to make it mandatory only if `--checkpermissionable` is used (except if there is an easy way to do it that I don't know about), and I would have to write some code to get what I'm having out of the box with `requiresUsername`. Also, this command is likely a one time only command, not something you would put in your CI. 

2 small other "updates" included:
* I've added a verbose flag, to see details of the json that was loggued in the console before
* I've moved the npm build script from rm to rimraf, to be able to build on a Windows machine
