### PR TITLE
Typo in activate theme

### DIFF
--- a/src/commands/shane/theme/activate.ts
+++ b/src/commands/shane/theme/activate.ts
@@ -50,7 +50,7 @@ export default class ThemeActivate extends SfdxCommand {
         await page.goto(url, {
             waitUntil: 'networkidle2'
         });
-        await page.waitForSelector(`tr[data-row-key-value='${themeId}'`, { visible: true });
+        await page.waitForSelector(`tr[data-row-key-value='${themeId}']`, { visible: true });
 
         // open up the dropdown menu to populate the Activate link
         if (orgApiVersion < 47) {


### PR DESCRIPTION
Fixes error: 
```
ERROR running shane:theme:activate:  waiting for selector "tr[data-row-key-
value='0S16E0000008PjMSAU'" failed: timeout 30000ms exceeded
```
