### PR TITLE
Convert localFile2CV to multipart form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "shane-sfdx-plugins",
     "description": "sfdx plugins by Shane McLaughlin",
-    "version": "4.9.4",
+    "version": "4.10.0",
     "author": "@mshanemc",
     "bugs": "https://github.com/mshanemc/shane-sfdx-plugins/issues",
     "dependencies": {
@@ -51,6 +51,7 @@
         "jest": "^24.3.1",
         "lint-staged": ">=8",
         "prettier": "^1.18.2",
+        "rimraf": "^3.0.0",
         "ts-jest": "^24.0.0",
         "ts-node": "^7.0.1",
         "tslint": "^5.13.0",
@@ -120,8 +121,8 @@
     },
     "repository": "mshanemc/shane-sfdx-plugins",
     "scripts": {
-        "build": "rm -rf lib && tsc",
-        "clean": "rm -f .oclif.manifest.json",
+        "build": "rimraf lib && tsc",
+        "clean": "rimraf .oclif.manifest.json",
         "postpublish": "yarn run clean; git push; git push --tags",
         "posttest": "",
         "prepare": "yarn run build && oclif-dev manifest",

--- a/src/shared/localFile2CV.ts
+++ b/src/shared/localFile2CV.ts
@@ -4,24 +4,35 @@ import fs = require('fs-extra');
 import { CreateResult, QueryResult, Record } from './../shared/typeDefs';
 
 interface ContentVersionCreateRequest {
-    VersionData: string;
     PathOnClient: string;
     Title?: string;
 }
 
 export async function file2CV(conn: Connection, filepath: string, name?: string): Promise<Record> {
-    const fileData = await fs.readFile(filepath);
+    const apiVersion = conn.getApiVersion();
+
     const cvcr = <ContentVersionCreateRequest>{
-        VersionData: Buffer.from(fileData).toString('base64'),
-        PathOnClient: filepath
+        PathOnClient: filepath,
+        Title: name
     };
-    // optinal params
-    if (name) {
-        cvcr.Title = name;
-    }
 
-    const CV = <CreateResult>await conn.sobject('ContentVersion').create(cvcr);
-
+    // Build the multi-part form data to be passed to the Request
+    const formData = {
+        entity_content: {
+            value: JSON.stringify(cvcr),
+            options: {
+                contentType: 'application/json'
+            }
+        },
+        VersionData: fs.createReadStream(filepath)
+    };
+    // POST the multipart form to Salesforce's API, can't use the normal "create" action because it doesn't support multipart
+    // Had to bypass the type def to allow formData to pass through, will try and get it patched into the type def later
+    // it is handled correctly by the underlying 'requst' library.
+    // https://github.com/request/request#multipartform-data-multipart-form-uploads
+    const CV = <
+        CreateResult // tslint:disable-next-line:no-any
+    >(<unknown>await conn.request(<any>{ url: `/services/data/v${apiVersion}/sobjects/ContentVersion`, formData, method: 'POST' }));
     const result = <QueryResult>await conn.query(`Select Id, ContentDocumentId from ContentVersion where Id='${CV.id}'`);
     return result.records[0];
 }


### PR DESCRIPTION
Changed localFile2CV to leverage multipart form-data instead of direct JSON.

Bumped the Feature version.

Also changed to using the platform agnostic rimraf instead of the mac specific "rm -f" for the build and clean tasks.