### PR TITLE
Fix: `--deleteconstraint` being ignored in cli mode

### DIFF
--- a/src/commands/shane/object/field.ts
+++ b/src/commands/shane/object/field.ts
@@ -197,12 +197,12 @@ export default class FieldCreate extends SfdxCommand {
                 this.flags.rellabel || (await cli.prompt('Child relationship label?', { default: outputJSON.relationshipName }));
         }
         if (this.flags.type === 'Lookup' && this.flags.object.endsWith('__c')) {
-            outputJSON.deleteConstraint = this.flags.interactive
-                ? this.flags.deleteconstraint ||
-                  (await cli.prompt(`What should happen to this field when the parent is deleted? (${deleteConstraintOptions.join(',')})`, {
-                      default: 'SetNull'
-                  }))
-                : 'SetNull';
+            outputJSON.deleteConstraint =
+                this.flags.deleteconstraint || this.flags.interactive
+                    ? await cli.prompt(`What should happen to this field when the parent is deleted? (${deleteConstraintOptions.join(',')})`, {
+                          default: 'SetNull'
+                      })
+                    : 'SetNull';
         }
         if (this.flags.type === 'MasterDetail') {
             outputJSON.reparentableMasterDetail = this.flags.interactive


### PR DESCRIPTION
The `sfdx shane:object:field` command ignores the `--deleteconstraint` flag and defaults to `SetNull` if not run in interactive mode.

https://github.com/mshanemc/shane-sfdx-plugins/blob/b7cdf5c8d5cab8bf7fdcd4416261a5b4b294d138/src/commands/shane/object/field.ts#L199-L205