### PR TITLE
Fix for custom activity fields

### DIFF
--- a/src/commands/shane/object/perms/align.ts
+++ b/src/commands/shane/object/perms/align.ts
@@ -108,6 +108,8 @@ export default class PermAlign extends SfdxCommand {
                     const objectName = item.layout.split('-')[0];
                     if (objects.includes(objectName) && layouts.includes(`${item.layout}.layout-meta.xml`)) {
                         return true;
+                    } else if (objectName == 'Global' && layouts.includes(`${item.layout}.layout-meta.xml`)) {
+                        return true;
                     }
                     this.ux.log(`${chalk.cyan(targetFilename)}: removing layout assignment for ${item.layout}`);
                     return false;

--- a/src/commands/shane/object/perms/align.ts
+++ b/src/commands/shane/object/perms/align.ts
@@ -95,6 +95,8 @@ export default class PermAlign extends SfdxCommand {
                     const fieldName = `${item.field.split('.')[1]}.field-meta.xml`;
                     if (objects.includes(objectName) && fs.readdirSync(`${objDir}/${objectName}/fields`).includes(fieldName)) {
                         return true;
+                    } else if ((objectName == 'Task' || objectName == 'Event') && fs.readdirSync(`${objDir}/Activity/fields`).includes(fieldName)) {
+                        return true;
                     }
                     this.ux.log(`${chalk.cyan(targetFilename)}: removing field perm for ${item.field}`);
                     return false;


### PR DESCRIPTION
This addresses the scenario that is caused by custom Activity fields written to the Activity/fields dir while the FLS for these fields is written to the Task and Event object. 